### PR TITLE
Fixed searcher.log file output paths

### DIFF
--- a/log.py
+++ b/log.py
@@ -1,6 +1,11 @@
 import logging
 import logging.handlers as handlers
 
+import sys  # for grabbing the program directory
+import os  # for splitting sys.argv
+PROGRAM_PATH = os.path.split(sys.argv[0])[0]
+LOG_PATH = os.path.join(PROGRAM_PATH, 'logs', 'searcher.log')
+
 # BEGIN Logger setup
 file_formatter = logging.Formatter(
     '%(asctime)s:'
@@ -21,7 +26,7 @@ stream_handler = logging.StreamHandler()
 stream_handler.setFormatter(stream_formatter)
 stream_handler.setLevel(logging.INFO)
 
-searcher_handler = handlers.RotatingFileHandler('searcher.log',
+searcher_handler = handlers.RotatingFileHandler(LOG_PATH,
                                                 maxBytes=500000, backupCount=5)
 searcher_handler.setFormatter(file_formatter)
 searcher_handler.setLevel(logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ py2exe usage:
 try:
 
     from distutils.core import setup
-    import py2exe, sys, TodoTracker
+    import py2exe  # used by py2app
+    import sys
+    import TodoTracker
 
     sys.argv.append('py2exe')
 
@@ -44,7 +46,7 @@ except ImportError:
     import TodoTracker
 
     APP = ['TodoTracker.py']
-    DATA_FILES = []
+    DATA_FILES = ['logs']
     OPTIONS = {}
 
     setup(


### PR DESCRIPTION
Closes #12

Retrieves the script path from sys.argv, then appends the path
'logs/searcher.log' to it. Passes that path to the log handler.